### PR TITLE
ISICO-15105:  Set Task startTime when calling updateTask to IN_PROGRESS

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -758,6 +758,10 @@ public class WorkflowExecutor {
             return;
         }
 
+        if (taskResult.getStatus() == TaskResult.Status.IN_PROGRESS && task.getStartTime() == 0) {
+            task.setStartTime(System.currentTimeMillis());
+        }
+	
         // for system tasks, setting to SCHEDULED would mean restarting the task which is
         // undesirable
         // for worker tasks, set status to SCHEDULED and push to the queue


### PR DESCRIPTION
when not set.

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
