### PR TITLE
ISICO-15117: Publish conductor-core of CiscoM31, which is required by

### DIFF
--- a/.github/workflows/ciscom31_publish_jar.yml
+++ b/.github/workflows/ciscom31_publish_jar.yml
@@ -68,4 +68,12 @@ jobs:
           commit: ${{ github.sha }}
           tag: ${{ steps.tag.outputs.TAG }}
           token: ${{ github.token }}
+      # publish list of jar files that are required for CiscoM31/conductor-community
+      - name: Upload conductor-core JAR
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "core/build/libs/conductor-core-*.jar"
+          commit: ${{ github.sha }}
+          tag: ${{ steps.tag.outputs.TAG }}
+          token: ${{ github.token }}
 


### PR DESCRIPTION
ISICO-15117: Publish conductor-core of CiscoM31, which is required by CiscoM31/conductor-community.

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
