### PR TITLE
ISCDETS-34689: redis-lock is included

### DIFF
--- a/redis-lock/build.gradle
+++ b/redis-lock/build.gradle
@@ -1,3 +1,4 @@
+group = 'com.cisco.conductor'
 dependencies {
     implementation project(':conductor-core')
     compileOnly 'org.springframework.boot:spring-boot-starter'


### PR DESCRIPTION
redis-lock is also included in the ciscom31 jar deliverable

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
