### PR TITLE
ISCDETS-34689: REPLICATED mode added for Redission

### DIFF
--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
@@ -94,6 +94,14 @@ public class RedisLockConfiguration {
                         .setPassword(redisServerPassword)
                         .setTimeout(connectionTimeout);
                 break;
+            case REPLICATED:
+                LOGGER.info("Setting up Redis Replicated Servers for RedisLockConfiguration");
+                redisConfig
+                        .useReplicatedServers()
+                        .setScanInterval(2000)
+                        .setPassword(redisServerPassword)
+                        .setTimeout(connectionTimeout)
+                        .addNodeAddress(redisServerAddress.split(","));
         }
 
         return (Redisson) Redisson.create(redisConfig);

--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
@@ -146,6 +146,7 @@ public class RedisLockProperties {
     public enum REDIS_SERVER_TYPE {
         SINGLE,
         CLUSTER,
-        SENTINEL
+        SENTINEL,
+        REPLICATED
     }
 }


### PR DESCRIPTION
As intersight's redis deployment is replicated, conductor has to support REPLICATED redis mode. Added code to support REPLICATED mode.



Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
