### PR TITLE
ISCDETS-34689: debug log removed

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1026,7 +1026,6 @@ public class WorkflowExecutor {
         } finally {
             executionLockService.releaseLock(workflowId);
             watch.stop();
-            LOGGER.info("decide method took {} milliseconds", watch.getTime());
             Monitors.recordWorkflowDecisionTime(watch.getTime());
         }
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1397,6 +1397,9 @@ public class WorkflowExecutor {
                 task.getWorkflowPriority(),
                 taskQueueName,
                 task.getCallbackAfterSeconds());
+        // Notify Task Push Notification
+        LOGGER.debug("Add task '{}' to publish.", task.getTaskId());
+        taskStatusListener.onTaskScheduled(task);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Invoking RetryFailed on a failed workflow fails and workflow is hanging. This is because task schedule notification is not sent while RetryFailed in invoked. Added the task notification to be sent on RetryFailed. 

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
