### PR TITLE
ISCDETS-34689: duplicate task notification is fixed

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -1577,16 +1577,6 @@ public class WorkflowExecutor {
     private void addTaskToQueue(final List<TaskModel> tasks) {
         for (TaskModel task : tasks) {
             addTaskToQueue(task);
-            // notify TaskStatusListener
-            try {
-                taskStatusListener.onTaskScheduled(task);
-            } catch (Exception e) {
-                String errorMsg =
-                        String.format(
-                                "Error while notifying TaskStatusListener: %s for workflow: %s",
-                                task.getTaskId(), task.getWorkflowInstanceId());
-                LOGGER.error(errorMsg, e);
-            }
         }
     }
 


### PR DESCRIPTION
Problem:

Task scheduled notification is sent twice to fusion when the task is scheduled. This is because we are invoking onTaskScheduled() method in two places one in addTaskToQueue(Task task) and another in addTaskToQueue(List<Task> taskList) method. 

Solution:

Remove the onTaskScheduled() method invocation in the addTaskToQueue(List<Task> taskList) method.


Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
